### PR TITLE
make _autoload dependency optional

### DIFF
--- a/config/autoload.ini
+++ b/config/autoload.ini
@@ -2,4 +2,4 @@
 ; List modules which are required to be loaded beforehand
 ;;
 requires[] = "core"
-requires[] = "_autoload"
+requires[] = "*_autoload"


### PR DESCRIPTION
This should fix
```
Exception occured: An error occurred while executing the "contao:install-web-dir" command: 
In ContaoModuleBundle.php line 36:
                                                                
  The module folder "system/modules/_autoload" does not exist.
```
https://community.contao.org/de/showthread.php?69777-Instagram-Bilder-Videos-in-Contao-einbinden&p=464842&viewfull=1#post464842