### PR TITLE
Unlock Doctrine 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "guzzlehttp/guzzle": "~6.0",
         "kevinrob/guzzle-cache-middleware": "^3.2",
         "doctrine/cache": "^1.9",
-        "doctrine/dbal": "^3.0"
+        "doctrine/dbal": "^2.10 || ^3.0"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.0",


### PR DESCRIPTION
The changes from https://github.com/codefog/contao-instagram/commit/d205df9f29821a4466e8f01e06984bf9aeee0012 are actually compatible with Doctrine >=2.10. This PR unlocks Doctrine 2.x again - otherwise this and future versions of this extension are not installable in Contao 4.9 anymore.