### PR TITLE
Check if response has data

### DIFF
--- a/src/Controller/FrontendModule/InstagramController.php
+++ b/src/Controller/FrontendModule/InstagramController.php
@@ -99,7 +99,7 @@ class InstagramController extends AbstractFrontendModuleController
 
         $response = $this->client->getMediaData($moduleModel->cfg_instagramAccessToken, (int) $moduleModel->id, true, (bool) $moduleModel->cfg_skipSslVerification);
 
-        if (null === $response) {
+        if (null === $response || null === ($response['data'] ?? null)) {
             return [];
         }
 


### PR DESCRIPTION
According to our sentry logs it can sometimes happen that the Facebook API does not return data and thus the following error occurs:

```
TypeError: array_filter(): Argument #1 ($array) must be of type array, null given
#42 /vendor/codefog/contao-instagram/src/Controller/FrontendModule/InstagramController.php(111): array_filter
#41 /vendor/codefog/contao-instagram/src/Controller/FrontendModule/InstagramController.php(111): Codefog\InstagramBundle\Controller\FrontendModule\InstagramController::getFeedItems
#40 /vendor/codefog/contao-instagram/src/Controller/FrontendModule/InstagramController.php(33): Codefog\InstagramBundle\Controller\FrontendModule\InstagramController::getResponse
#39 /vendor/contao/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php(40): Contao\CoreBundle\Controller\FrontendModule\AbstractFrontendModuleController::__invoke
#38 /vendor/symfony/http-kernel/HttpKernel.php(163): Symfony\Component\HttpKernel\HttpKernel::handleRaw
#37 /vendor/symfony/http-kernel/HttpKernel.php(75): Symfony\Component\HttpKernel\HttpKernel::handle
#36 /vendor/symfony/http-kernel/HttpCache/SubRequestHandler.php(86): Symfony\Component\HttpKernel\HttpCache\SubRequestHandler::handle
#35 /vendor/symfony/http-kernel/Fragment/InlineFragmentRenderer.php(80): Symfony\Component\HttpKernel\Fragment\InlineFragmentRenderer::render
#34 /vendor/symfony/http-kernel/Fragment/FragmentHandler.php(85): Symfony\Component\HttpKernel\Fragment\FragmentHandler::render
#33 /vendor/contao/core-bundle/src/Fragment/FragmentHandler.php(69): Contao\CoreBundle\Fragment\FragmentHandler::render
#32 /vendor/contao/core-bundle/src/Resources/contao/modules/ModuleProxy.php(60): Contao\ModuleProxy::generate
#31 /vendor/contao/core-bundle/src/Resources/contao/library/Contao/Controller.php(442): Contao\Controller::getFrontendModule
```

This PR introduces a check whether the `data` key is present in the JSON decoded response.