### PR TITLE
fix crash if Instagram store folder disabled

### DIFF
--- a/contao/templates/modules/mod_cfg_instagram.html5
+++ b/contao/templates/modules/mod_cfg_instagram.html5
@@ -5,7 +5,7 @@
 <?php foreach ($this->items as $item): ?>
     <div class="item">
         <a href="<?= \Contao\StringUtil::specialchars($item['permalink']) ?>" target="_blank"<?php if ($item['caption']): ?> title="<?= \Contao\StringUtil::specialchars($item['caption']) ?>"<?php endif; ?>>
-            <?php if ($item['contao']['picture']): ?>
+            <?php if (isset($item['contao']['picture'])): ?>
                 <?php $this->insert('picture_default', $item['contao']['picture']->picture) ?>
             <?php else: ?>
                 <img src="<?= $item['thumbnail_url'] ?? $item['media_url'] ?>" alt="<?= \Contao\StringUtil::specialchars($item['caption']) ?>">


### PR DESCRIPTION
If the Instagram store folder is disabled in the module, the current code will throw an error. To prevent this we check for asset to not run into this error if said field does not exist on $item