### PR TITLE
Instagram API with Instagram Login

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,10 +2,10 @@
 
 ## Create an Instagram app
 
-First of all you have to create the Instagram app. For that please follow the [official Getting Started guide](https://developers.facebook.com/docs/instagram-basic-display-api/getting-started)
-up until point 3 (inclusive).
+First of all you have to create the Instagram app. For that please follow the [official Getting Started guide](https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login/create-a-meta-app-with-instagram)
+up until point 6 (inclusive).
 
-One important thing to note is that for all app URIs listed:
+Then, it is important to configure all app URIs, as described in Step 9:
 
 - Valid OAuth Redirect URIs
 - Deauthorize Callback URL

--- a/src/EventListener/ModuleListener.php
+++ b/src/EventListener/ModuleListener.php
@@ -66,7 +66,7 @@ class ModuleListener
             'app_id' => $clientId,
             'redirect_uri' => $this->router->generate('instagram_auth', [], UrlGeneratorInterface::ABSOLUTE_URL),
             'response_type' => 'code',
-            'scope' => 'user_profile,user_media',
+            'scope' => 'instagram_business_basic',
         ];
 
         throw new RedirectResponseException('https://api.instagram.com/oauth/authorize/?'.http_build_query($data));


### PR DESCRIPTION
As Instagram Basic Display Api is deprecated, there is one change needed on bundle side.

According to https://developers.facebook.com/docs/permissions#i the required permission to read profile information and media of an Instagram business account is _instagram_business_basic_.

In Addition, you need to create an Instagram API with Instagram Login according to this guide https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login/create-a-meta-app-with-instagram until Step 6 and Step 9 ! The rest is not needed, as you only want to get media of your own Instagram Account.

IMPORTANT:  This is only working for instagram business accounts, not for regular accounts!

I tested this on my website and it is running for several days now. also the refreshing of the access token is working!